### PR TITLE
Defined types to add groups to users

### DIFF
--- a/manifests/grant/administrators.pp
+++ b/manifests/grant/administrators.pp
@@ -1,0 +1,14 @@
+# Grant accounts Administrators access on Windows
+#
+# This takes all accounts in a specified group, and adds them to the
+# Administrators group. For example, I might want to give all the sysadmins
+# administrative access:
+#
+# ~~~ puppet
+# account::grant::administrators { 'sysadmin': }
+# ~~~
+define account::grant::administrators (
+  String[1] $to_group = $title,
+) {
+  account::grant::group { "Administrators>${to_group}": }
+}

--- a/manifests/grant/group.pp
+++ b/manifests/grant/group.pp
@@ -1,0 +1,26 @@
+# Grant accounts access to a specific group
+#
+# This grants all accounts with access to one group, access to another group.
+# For example, I might want to grant everybody in the sysadmin group access to
+# adm group:
+#
+# ~~~ puppet
+# account::grant::group { 'adm>sysadmin': }
+# ~~~
+#
+# Another way of doing the same thing:
+#
+# ~~~ puppet
+# account::grant::group { 'give sysadmins adm access':
+#   new_group => 'adm',
+#   to_group  => 'sysadmin',
+# }
+# ~~~
+define account::grant::group (
+  String[1] $new_group = $title.split('>')[0],
+  String[1] $to_group = $title.split('>')[1],
+) {
+  User <| groups == $to_group or gid == $to_group |> {
+    groups +> [$new_group],
+  }
+}

--- a/manifests/grant/rdp.pp
+++ b/manifests/grant/rdp.pp
@@ -1,0 +1,13 @@
+# Grant accounts RDP access on Windows
+#
+# This takes all accounts in a specified group, and adds them to the Remote
+# Desktop Users group. For example, I might want to give all users RDP access:
+#
+# ~~~ puppet
+# account::grant::rdp { 'Users': }
+# ~~~
+define account::grant::rdp (
+  String[1] $to_group = $title,
+) {
+  account::grant::group { "Remote Desktop Users>${to_group}": }
+}


### PR DESCRIPTION
These types can be used to add more groups to users based on their existing group membership.

For example, the following code adds the “Administrators” group to all users with group “foo”.

~~~ puppet
account::user { 'alice':
  group => 'foo',
}

account::user { 'bob':
  groups => ['foo'],
}

if $facts['foo_power'] > 9000 {
  account::grant::administrators { 'foo': }
}
~~~

This is particularly useful on Windows nodes, where access to things like RDP and administrative powers are determined by group membership. I often want a team to have admin access on one server, but not on another — this makes that sort of logic possible.