### PR TITLE
Bump Minimum ssh Module Version

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -11,7 +11,7 @@ fixtures:
       ref: "a0ee04c65d89ca648113e96d15c5001c70fc718d"
     ssh:
       repo: "https://github.com/ploperations/ploperations-ssh"
-      tag: "0.9.0"
+      tag: "0.10.0"
     zsh:
       repo: "https://github.com/ploperations/ploperations-zsh"
       ref: "78e1e1b866dd8082768ce5cef60b0e3680a79137"

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "ploperations/ssh",
-      "version_requirement": ">= 0.2 < 2.0.0"
+      "version_requirement": ">= 0.10.0 < 1.0.0"
     },
     {
       "name": "ploperations/zsh",


### PR DESCRIPTION
The tightly coupled dependent ssh module had a minor version bump, so labeling this with "feature" for future minor version bump of this module as well.