### PR TITLE
Fix changelog date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
-## [2.0.0](https://github.com/ploperations/ploperations-account/tree/2.0.0) (2021-09-17)
+## [2.0.0](https://github.com/ploperations/ploperations-account/tree/2.0.0) (2021-09-18)
 
 [Full Changelog](https://github.com/ploperations/ploperations-account/compare/1.1.0...2.0.0)
 


### PR DESCRIPTION
It seems the github-changelog-generator uses UTC so now it think it is tomorrow instead of today :(