### PR TITLE
Add auto_home settings

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,6 +5,7 @@ fixtures:
   forge_modules:
     # Most of these are dependencies of puppetlabs/ssh.
     acl: 'puppetlabs/acl'
+    augeas_core: 'puppetlabs/augeas_core'
     bash: 'ploperations/bash'
     chocolatey: 'puppetlabs/chocolatey'
     classification: 'ploperations/classification'

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -79,7 +79,8 @@ define account::user (
   if $password {
     $_password = $password
   } else {
-    $hiera_accounts = lookup( {
+    $hiera_accounts = lookup(
+      {
         name          => 'account::user',
         value_type    => Hash[String[1], Hash],
         default_value => {},


### PR DESCRIPTION
This module already assumed that automatic home directory mapping was
happening as it is the traditional default on Solaris. This adds a
setting in to account for ensuring the settings are in place and makes
using these traditional defaults optional.

This fixes #28